### PR TITLE
Fix source warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ gemfiles/*.gemfile.lock
 spec/dummy/db
 spec/dummy/log
 spec/dummy/tmp
+/.idea

--- a/lib/caracal/rails/template_handler.rb
+++ b/lib/caracal/rails/template_handler.rb
@@ -1,11 +1,11 @@
 module Caracal
   module Rails
     class TemplateHandler
-      
-      def self.call(template)
+
+      def self.call(template, _source)
         "Tilt.new('#{ template.identifier }').render(self)"
       end
-      
+
     end
   end
 end

--- a/spec/lib/caracal/rails/template_handler_spec.rb
+++ b/spec/lib/caracal/rails/template_handler_spec.rb
@@ -1,21 +1,21 @@
 require 'spec_helper'
 
 describe Caracal::Rails::TemplateHandler do
-    
+
   #--------------------------------------------------------
   # Class Methods
   #--------------------------------------------------------
-  
+
   describe 'class method tests' do
-    
+
     # .call
     describe '#call' do
       let(:template) { double('template', identifier: 'show.docx.caracal') }
-      let(:actual)   { Caracal::Rails::TemplateHandler.call(template) }
-      
+      let(:actual)   { Caracal::Rails::TemplateHandler.call(template, nil) }
+
       it { expect(actual).to eq "Tilt.new('show.docx.caracal').render(self)" }
     end
-    
+
   end
-  
+
 end


### PR DESCRIPTION
Gets rid of arity warning for rails 6.0+. Pointed local app to this, ran rails and specs that use the gem, and the change does not appear to have broken anything. Also added an ignore for .idea directory for RubyMine users.